### PR TITLE
Feature/receive file

### DIFF
--- a/client/fileChange/stackMiddle.go
+++ b/client/fileChange/stackMiddle.go
@@ -50,7 +50,6 @@ func Middle(wg *sync.WaitGroup, ctx context.Context, dirPath string) {
 		for {
 			select {
 			case <-ticker.C:
-				fmt.Println("Tick")
 			case <-initStackIticker.C:
 				initStack(&stack)
 			case <-ctx.Done():

--- a/client/fileReceive/fileReceive.go
+++ b/client/fileReceive/fileReceive.go
@@ -1,0 +1,70 @@
+package fileReceive
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func ReceiveFile(fileName string, dirPath string, server string) {
+	fmt.Println("Starting file download...")
+
+	// --- NEW LOGIC HERE ---
+	// The rendered filename is based on your shell script's output
+	// e.g., "untitled_render0001.png" from "untitled.blend"
+	renderFileName := fileName
+	if filepath.Ext(fileName) == ".blend" {
+		base := fileName[:len(fileName)-len(filepath.Ext(fileName))]
+		renderFileName = fmt.Sprintf("%s_render0001.png", base)
+	}
+	// --- END OF NEW LOGIC ---
+
+	// Construct the download URL using the CORRECT rendered filename.
+	// This is the CRITICAL change!
+	downloadURL := fmt.Sprintf("%s/download?file=%s", server, renderFileName)
+
+	// Polling loop to wait for the file to be available for download
+	// This is a simple retry mechanism.
+	maxRetries := 5
+	for i := 0; i < maxRetries; i++ {
+		resp, err := http.Get(downloadURL)
+		if err != nil {
+			log.Printf("Download failed: %v. Retrying...", err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			// File found and ready to download
+			fullFilePath := filepath.Join(dirPath, renderFileName)
+			out, err := os.Create(fullFilePath)
+			if err != nil {
+				log.Printf("Error creating local file: %v", err)
+				return
+			}
+			defer out.Close()
+
+			_, err = io.Copy(out, resp.Body)
+			if err != nil {
+				log.Printf("Error writing to file: %v", err)
+				return
+			}
+
+			fmt.Printf("✅ File downloaded successfully to %s\n", fullFilePath)
+			return
+		} else if resp.StatusCode == http.StatusNotFound {
+			log.Printf("Server not ready for download. Status: %s. Retrying...", resp.Status)
+			time.Sleep(2 * time.Second)
+			continue
+		} else {
+			log.Printf("Unexpected status code from server: %d", resp.StatusCode)
+			return
+		}
+	}
+	log.Println("Failed to download file after multiple retries.")
+}

--- a/client/fileTransfer/sendFile.go
+++ b/client/fileTransfer/sendFile.go
@@ -2,7 +2,7 @@ package filetransfer
 
 import (
 	"bytes"
-	"encoding/json" // New import for JSON handling
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -23,8 +23,9 @@ const (
 
 // JobStatus is a local representation of the server's status struct.
 type JobStatus struct {
-	Status   string `json:"status"`
-	Progress int    `json:"progress"`
+	Status        string `json:"status"`
+	Progress      int    `json:"progress"`
+	RemainingTime string `json:"remainingTime"` // Add this new field
 }
 
 func SendFile(fileName string, dirPath string) {
@@ -109,7 +110,7 @@ func SendFile(fileName string, dirPath string) {
 			}
 		}
 
-		fmt.Printf("Server status for %s: %s (progress: %d%%)\n", fileName, jobStatus.Status, jobStatus.Progress)
+		fmt.Printf("Server status for %s: %s (progress: %d%%, remaining: %s)\n", fileName, jobStatus.Status, jobStatus.Progress, jobStatus.RemainingTime)
 
 		if jobStatus.Status == "done" {
 			fmt.Println("✅ Rendering completed! Downloading the rendered image from server...")

--- a/client/fileTransfer/sendFile.go
+++ b/client/fileTransfer/sendFile.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/0Shree005/DistributedRendering/client/fileReceive"
 	"github.com/joho/godotenv"
 )
 
@@ -87,7 +88,8 @@ func SendFile(fileName string, dirPath string) {
 		fmt.Println("Server status:", status)
 
 		if contains(status, "done") {
-			fmt.Println("✅ Rendering completed!")
+			fmt.Println("✅ Rendering completed! Downloading the rendered image from server...")
+			fileReceive.ReceiveFile(fileName, dirPath, server)
 			break
 		}
 		if contains(status, "failed") {

--- a/server/handlers/downloadHandler.go
+++ b/server/handlers/downloadHandler.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func DownloadHandler(w http.ResponseWriter, r *http.Request) {
+	fileName := r.URL.Query().Get("file")
+	if fileName == "" {
+		http.Error(w, "Missing 'file' parameter", http.StatusBadRequest)
+		return
+	}
+
+	// Construct the full path to the rendered file.
+	// It's important to sanitize the input to prevent directory traversal attacks.
+	safeFileName := filepath.Base(fileName)
+	filePath := filepath.Join("./renders", safeFileName)
+
+	// Check if the file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		http.Error(w, "File not found", http.StatusNotFound)
+		return
+	}
+
+	// Serve the file to the client.
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", safeFileName))
+	w.Header().Set("Content-Type", "image/png") // Assuming PNG format based on your script
+	http.ServeFile(w, r, filePath)
+
+	// Optional: Delete the file after it has been served successfully.
+	// This helps manage server disk space.
+	go func() {
+		fmt.Printf("Attempting to delete file: %s\n", filePath)
+		if err := os.Remove(filePath); err != nil {
+			fmt.Printf("Failed to delete file %s: %v\n", filePath, err)
+		} else {
+			fmt.Printf("Successfully deleted file: %s\n", filePath)
+		}
+		// You might also want to remove the entry from renderJobs sync.Map
+		// once the file has been successfully downloaded.
+		renderJobs.Delete(fileName)
+	}()
+}

--- a/server/handlers/statusHander.go
+++ b/server/handlers/statusHander.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/http"
 )
 
@@ -13,7 +13,8 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if val, ok := renderJobs.Load(file); ok {
-		w.Write([]byte(fmt.Sprintf("Status for %s: %s\n", file, val)))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(val)
 	} else {
 		http.Error(w, "File not found", http.StatusNotFound)
 	}

--- a/server/handlers/uploadHandler.go
+++ b/server/handlers/uploadHandler.go
@@ -36,16 +36,16 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("File %s received successfully!\n", header.Filename)
 		w.Write([]byte("File uploaded. Rendering started.\n"))
 
-		// Mark as in-progress with 0% progress
-		renderJobs.Store(header.Filename, &types.JobStatus{Status: "in-progress", Progress: 0})
+		// Mark as in-progress with 0% progress and no remaining time
+		renderJobs.Store(header.Filename, &types.JobStatus{Status: "in-progress", Progress: 0, RemainingTime: ""})
 
 		// Run Blender async
 		go func(fname string) {
 			err := scripts.StartRendering(fname, &renderJobs)
 			if err != nil {
-				renderJobs.Store(fname, &types.JobStatus{Status: "failed", Progress: 0})
+				renderJobs.Store(fname, &types.JobStatus{Status: "failed", Progress: 0, RemainingTime: ""})
 			} else {
-				renderJobs.Store(fname, &types.JobStatus{Status: "done", Progress: 100})
+				renderJobs.Store(fname, &types.JobStatus{Status: "done", Progress: 100, RemainingTime: "00:00.00"})
 			}
 		}(header.Filename)
 

--- a/server/handlers/uploadHandler.go
+++ b/server/handlers/uploadHandler.go
@@ -2,15 +2,17 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/0Shree005/DistributedRendering/server/scripts"
 	"io"
 	"net/http"
 	"os"
 	"regexp"
 	"sync"
+
+	"github.com/0Shree005/DistributedRendering/server/scripts"
+	"github.com/0Shree005/DistributedRendering/server/types"
 )
 
-var renderJobs sync.Map // to track status of the file rendering (filename -> status {"inProgress", "done", "failed"})
+var renderJobs sync.Map // to track status of the file rendering (filename -> *types.JobStatus)
 
 func UploadHandler(w http.ResponseWriter, r *http.Request) {
 	file, header, err := r.FormFile("file")
@@ -34,16 +36,16 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("File %s received successfully!\n", header.Filename)
 		w.Write([]byte("File uploaded. Rendering started.\n"))
 
-		// Mark as in-progress
-		renderJobs.Store(header.Filename, "in-progress")
+		// Mark as in-progress with 0% progress
+		renderJobs.Store(header.Filename, &types.JobStatus{Status: "in-progress", Progress: 0})
 
 		// Run Blender async
 		go func(fname string) {
-			err := scripts.StartRendering(fname)
+			err := scripts.StartRendering(fname, &renderJobs)
 			if err != nil {
-				renderJobs.Store(fname, "failed")
+				renderJobs.Store(fname, &types.JobStatus{Status: "failed", Progress: 0})
 			} else {
-				renderJobs.Store(fname, "done")
+				renderJobs.Store(fname, &types.JobStatus{Status: "done", Progress: 100})
 			}
 		}(header.Filename)
 

--- a/server/main.go
+++ b/server/main.go
@@ -35,6 +35,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/upload", handlers.UploadHandler)
 	mux.HandleFunc("/status", handlers.StatusHandler)
+	mux.HandleFunc("/download", handlers.DownloadHandler)
 
 	handler := cors.AllowAll().Handler(mux)
 	http.ListenAndServe(ip+":5000", handler)

--- a/server/scripts/startRendering.go
+++ b/server/scripts/startRendering.go
@@ -28,22 +28,35 @@ func StartRendering(fileName string, renderJobs *sync.Map) error {
 	}
 
 	// This regex captures the progress from Blender's "Rendered X/Y Tiles" output.
-	re := regexp.MustCompile(`Rendered ([0-9]+)\/([0-9]+) Tiles`)
+	reProgress := regexp.MustCompile(`Rendered ([0-9]+)\/([0-9]+) Tiles`)
+	// This regex captures the remaining time from Blender's output.
+	reTime := regexp.MustCompile(`Remaining:([0-9:.]+)`)
 
 	// Read from stdout in a separate goroutine
 	go func() {
 		scanner := bufio.NewScanner(stdout)
+		currentStatus := &types.JobStatus{Status: "in-progress", Progress: 0, RemainingTime: ""}
 		for scanner.Scan() {
 			line := scanner.Text()
 			fmt.Println(line) // Log the output for debugging
-			match := re.FindStringSubmatch(line)
-			if len(match) == 3 {
-				renderedTiles, err1 := strconv.ParseFloat(match[1], 64)
-				totalTiles, err2 := strconv.ParseFloat(match[2], 64)
+
+			// Check for progress
+			matchProgress := reProgress.FindStringSubmatch(line)
+			if len(matchProgress) == 3 {
+				renderedTiles, err1 := strconv.ParseFloat(matchProgress[1], 64)
+				totalTiles, err2 := strconv.ParseFloat(matchProgress[2], 64)
 				if err1 == nil && err2 == nil && totalTiles > 0 {
 					progress := (renderedTiles / totalTiles) * 100
-					renderJobs.Store(fileName, &types.JobStatus{Status: "in-progress", Progress: int(progress)})
+					currentStatus.Progress = int(progress)
+					renderJobs.Store(fileName, currentStatus)
 				}
+			}
+
+			// Check for remaining time
+			matchTime := reTime.FindStringSubmatch(line)
+			if len(matchTime) == 2 {
+				currentStatus.RemainingTime = matchTime[1]
+				renderJobs.Store(fileName, currentStatus)
 			}
 		}
 	}()

--- a/server/scripts/startRendering.go
+++ b/server/scripts/startRendering.go
@@ -1,13 +1,19 @@
 package scripts
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
+	"strconv"
+	"sync"
+
+	"github.com/0Shree005/DistributedRendering/server/types"
 )
 
-func StartRendering(fileName string) error {
+func StartRendering(fileName string, renderJobs *sync.Map) error {
 	fmt.Println("Rendering file: ", fileName)
 
 	cmd := exec.Command("./startRender.sh", fileName)
@@ -21,7 +27,27 @@ func StartRendering(fileName string) error {
 		return fmt.Errorf("error starting command: %w", err)
 	}
 
-	go io.Copy(os.Stdout, stdout)
+	// This regex captures the progress from Blender's "Rendered X/Y Tiles" output.
+	re := regexp.MustCompile(`Rendered ([0-9]+)\/([0-9]+) Tiles`)
+
+	// Read from stdout in a separate goroutine
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			fmt.Println(line) // Log the output for debugging
+			match := re.FindStringSubmatch(line)
+			if len(match) == 3 {
+				renderedTiles, err1 := strconv.ParseFloat(match[1], 64)
+				totalTiles, err2 := strconv.ParseFloat(match[2], 64)
+				if err1 == nil && err2 == nil && totalTiles > 0 {
+					progress := (renderedTiles / totalTiles) * 100
+					renderJobs.Store(fileName, &types.JobStatus{Status: "in-progress", Progress: int(progress)})
+				}
+			}
+		}
+	}()
+
 	go io.Copy(os.Stderr, stderr)
 
 	if err := cmd.Wait(); err != nil {

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -1,0 +1,7 @@
+package types
+
+// JobStatus represents the state of a rendering job.
+type JobStatus struct {
+	Status   string `json:"status"`
+	Progress int    `json:"progress"`
+}

--- a/server/types/types.go
+++ b/server/types/types.go
@@ -2,6 +2,7 @@ package types
 
 // JobStatus represents the state of a rendering job.
 type JobStatus struct {
-	Status   string `json:"status"`
-	Progress int    `json:"progress"`
+	Status        string `json:"status"`
+	Progress      int    `json:"progress"`
+	RemainingTime string `json:"remainingTime"`
 }

--- a/web-portal/src/app/page.js
+++ b/web-portal/src/app/page.js
@@ -21,6 +21,8 @@ export default function App() {
   const [serverIp, setServerIp] = useState("http://192.168.x.x:5000");
   // State to manage the dropzone border color based on job status
   const [dropzoneBorderClass, setDropzoneBorderClass] = useState('border-zinc-800');
+  // New state to hold the URL of the rendered image
+  const [downloadUrl, setDownloadUrl] = useState('');
 
 
   // Reference to the hidden file input element
@@ -128,6 +130,8 @@ export default function App() {
               setProgress(100);
               setJobStatus("success");
               setStatusMessage("Rendering completed!");
+              // Construct the download URL and save it to state
+              setDownloadUrl(`${serverIp}/download?file=${renderFileName}`);
               break; // Exit the loop
             } else if (statusText.includes("failed")) {
               setErrorMessage("Rendering failed on the server.");
@@ -235,9 +239,22 @@ export default function App() {
             <p className="text-4xl mb-4">✅</p>
             <p className="text-lg font-bold">Rendering Completed!</p>
             <p className="text-sm text-gray-400">Your file &quot;{file?.name}&quot; has been rendered successfully.</p>
+            {downloadUrl && (
+              <a 
+                href={downloadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-green-700 text-white mt-4 font-bold py-2 px-6 rounded-full shadow-lg hover:bg-green-600 transition-colors border-2 border-green-600 inline-block mr-2"
+              >
+                View Render
+              </a>
+            )}
             <button
-              onClick={() => setJobStatus('idle')}
-              className="bg-zinc-700 text-white mt-4 font-bold py-2 px-6 rounded-full shadow-lg hover:bg-zinc-800 transition-colors border-2 border-zinc-600"
+              onClick={() => {
+                setJobStatus('idle');
+                setDownloadUrl(''); // Clear the URL when resetting
+              }}
+              className="bg-zinc-700 text-white mt-4 font-bold py-2 px-6 rounded-full shadow-lg hover:bg-zinc-800 transition-colors border-2 border-zinc-600 inline-block"
             >
               Upload Another
             </button>

--- a/web-portal/src/app/page.js
+++ b/web-portal/src/app/page.js
@@ -23,6 +23,8 @@ export default function App() {
   const [dropzoneBorderClass, setDropzoneBorderClass] = useState('border-zinc-800');
   // New state to hold the URL of the rendered image
   const [downloadUrl, setDownloadUrl] = useState('');
+  // New state to store the remaining time
+  const [remainingTime, setRemainingTime] = useState('');
 
 
   // Reference to the hidden file input element
@@ -69,6 +71,7 @@ export default function App() {
     setFile(uploadedFile);
     setJobStatus('idle');
     setProgress(0);
+    setRemainingTime('');
   };
 
   // The main function to handle file upload and rendering
@@ -129,9 +132,10 @@ export default function App() {
 
             console.log('Server status:', jobStatusData);
 
-            // Now we use the actual progress from the JSON object!
+            // Now we use the actual progress and remaining time from the JSON object!
             if (jobStatusData.status === "in-progress") {
               setProgress(jobStatusData.progress);
+              setRemainingTime(jobStatusData.remainingTime);
               setStatusMessage(`Rendering in progress: ${jobStatusData.progress}%`);
             } else if (jobStatusData.status === "done") {
               setProgress(100);
@@ -236,7 +240,10 @@ export default function App() {
                 style={{ width: `${progress}%` }}
               ></div>
             </div>
-            <p className="text-xs text-gray-400 mt-2">{progress}% Complete</p>
+            <p className="text-xs text-gray-400 mt-2">
+              {progress}% Complete
+              {remainingTime && ` - Remaining: ${remainingTime}`}
+            </p>
           </div>
         );
       case 'success':
@@ -259,6 +266,7 @@ export default function App() {
               onClick={() => {
                 setJobStatus('idle');
                 setDownloadUrl(''); // Clear the URL when resetting
+                setRemainingTime('');
               }}
               className="bg-zinc-700 text-white mt-4 font-bold py-2 px-6 rounded-full shadow-lg hover:bg-zinc-800 transition-colors border-2 border-zinc-600 inline-block"
             >


### PR DESCRIPTION
##  feat: Add rendered image download from server back to client and real-time progress polling

This pull request introduces a crucial new feature set, allowing the client and the new web portal to receive **real-time rendering status updates** and **download the final rendered image** upon completion. This significantly enhances the user experience by providing a more complete and transparent view of the rendering process.

### Key Changes

* **Rendered Image Download:** The client now automatically polls the server and downloads the final rendered `.png` file. A new `/download` endpoint has been added to the server to serve these files back to the client securely and then automatically delete them to save disk space.

* **Real time progress polling:** The client's status polling logic has been completely refactored. Instead of a simple `done`/`failed` check, it now receives a detailed JSON object from the server. This new object contains the **current progress percentage** and **estimated time remaining**, providing real-time feedback.

* **Real-time UI Updates:** The web portal and CLI have been updated to display the new progress and remaining time data, giving users a live view of their rendering job's status.

* **Improved Status Handling:** The server-side code has been refactored to use a dedicated `JobStatus` struct to manage rendering job states, ensuring data consistency.